### PR TITLE
Append user-supplied SSH public keys via extra_authorized_keys

### DIFF
--- a/includes/extra_authorized_keys.yml
+++ b/includes/extra_authorized_keys.yml
@@ -1,0 +1,43 @@
+---
+
+# Append OpenSSH public keys from var ``extra_authorized_keys`` to the
+# default cloud-init user's ``~/.ssh/authorized_keys``. Each key is added
+# with ``exclusive: no`` so we never wipe the auto-generated provisioning
+# key — losing that would leave the cluster unmanageable until destroy.
+#
+# ``os_user`` is set per distro in ``inventory/group_vars/distro/*.yml``
+# (ubuntu/rocky/centos all map to whatever cloud-init's default account
+# is). The ``mariadb`` user gets the same treatment so direct SSH as
+# either ubuntu@ or mariadb@ works.
+
+- hosts: "primary,replicas,maxscale"
+  become: yes
+  become_user: root
+  gather_facts: no
+  vars_files:
+    - '../inventory/group_vars/all.yml'
+
+  tasks:
+    - name: "Append extra SSH public keys to {{ os_user }}'s authorized_keys"
+      ansible.posix.authorized_key:
+        user: "{{ os_user }}"
+        key: "{{ item }}"
+        state: present
+        exclusive: no
+      loop: "{{ extra_authorized_keys | default([]) }}"
+      when: extra_authorized_keys is defined and extra_authorized_keys | length > 0
+
+    - name: "Append extra SSH public keys to mariadb's authorized_keys"
+      ansible.posix.authorized_key:
+        user: mariadb
+        key: "{{ item }}"
+        state: present
+        exclusive: no
+      loop: "{{ extra_authorized_keys | default([]) }}"
+      when: extra_authorized_keys is defined and extra_authorized_keys | length > 0
+      # The mariadb user is created by terraform_includes/create_user.sh
+      # via cloud-init; it may not exist yet on a host where cloud-init
+      # is still racing the first ansible pass, so don't fail provision
+      # just because mariadb hasn't materialised. Re-runs of the play
+      # close the gap on retry.
+      ignore_errors: yes

--- a/outputs.tf
+++ b/outputs.tf
@@ -101,6 +101,7 @@ resource "local_file" "AnsibleVariables" {
       internal_efs_enabled     = var.use_s3 ? false : true,
       internal_efs_dns_name    = var.use_s3 ? "" : aws_efs_file_system.internal_efs[0].dns_name,
       sentry_dsn               = var.sentry_dsn,
+      extra_authorized_keys    = var.extra_authorized_keys,
     }
   )
   filename = "inventory/group_vars/all.yml"

--- a/provision.yml
+++ b/provision.yml
@@ -36,6 +36,9 @@
 - name: "Dev support utils"
   import_playbook: includes/dev_utils.yml
 
+- name: "Append user-supplied SSH keys"
+  import_playbook: includes/extra_authorized_keys.yml
+
 #- name: "Setting Up GFS2"
 #  import_playbook: includes/gfs2.yml
 #  when: use_s3

--- a/terraform_includes/all.tmpl
+++ b/terraform_includes/all.tmpl
@@ -65,3 +65,9 @@ internal_efs_dns_name: "${internal_efs_dns_name}"
 
 # Sentry
 sentry_dsn: "${sentry_dsn}"
+
+# Extra SSH public keys appended to ubuntu's authorized_keys
+extra_authorized_keys:
+%{ for k in extra_authorized_keys ~}
+  - ${jsonencode(k)}
+%{ endfor ~}

--- a/variables.tf
+++ b/variables.tf
@@ -299,3 +299,15 @@ variable "sentry_dsn" {
   type        = string
   default     = ""
 }
+
+######## Extra SSH public keys
+
+# OpenSSH-format public keys appended to ubuntu@host:~/.ssh/authorized_keys
+# during ansible provisioning. Babylon populates this with the keys belonging
+# to the user who requested the cluster, so each operator gets direct shell
+# access without sharing the auto-generated provisioning private key.
+variable "extra_authorized_keys" {
+  description = "OpenSSH public keys to append to ubuntu's authorized_keys"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Summary

- New `extra_authorized_keys` (list(string), default = []) terraform variable, plumbed through `outputs.tf` → `terraform_includes/all.tmpl` → ansible group_vars → new `includes/extra_authorized_keys.yml` play.
- The play uses `ansible.posix.authorized_key` with `exclusive: no` to append each key to `ubuntu@host:~/.ssh/authorized_keys` (and best-effort `mariadb@host` — `ignore_errors: yes` covers the cloud-init race when the user hasn't been created yet).
- When the variable is empty (default), provisioning behaviour is unchanged — the new task loop just does nothing.

## Why

Companion to https://github.com/mariadb-corporation/babylon/pull/<TBD>. Babylon stores OpenSSH public keys per github user; at cluster-allocate time the worker injects the requester's keys into the TF run as `extra_authorized_keys`, so each operator gets direct shell access without sharing the auto-generated provisioning .pem.

## Test plan

- [ ] `terraform plan` with `extra_authorized_keys = []` shows no diff against the previous plan
- [ ] `terraform plan` with `extra_authorized_keys = ["ssh-ed25519 AAAA me@host"]` puts the key into ansible group_vars
- [ ] `ansible-playbook provision.yml` on a fresh cluster: `ssh ubuntu@<host>` succeeds with the user's own private key
- [ ] Re-running ansible doesn't wipe the original provisioning key from `~ubuntu/.ssh/authorized_keys`

🤖 Generated with [Claude Code](https://claude.com/claude-code)